### PR TITLE
Add price watch monitoring for high quality recommendations

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -48,7 +48,9 @@ export interface EmailCandidate {
   priceInsights?: Array<{
     ticker: string;
     entryPrice?: number | null;
+    entryTimestamp?: string | null;
     latestPrice?: number | null;
+    latestTimestamp?: string | null;
     movePct?: number | null;
     exceedsThreshold?: boolean;
     dataUnavailable?: boolean;
@@ -416,20 +418,21 @@ export async function selectForEmail(
   }
 }
 
-export async function markEmailed(config: Config, postIds: string[]): Promise<void> {
+export async function markEmailed(config: Config, postIds: string[], emailedAtIso?: string): Promise<void> {
   if (postIds.length === 0) {
     logger.debug('No posts to mark as emailed');
     return;
   }
 
   const supabase = getSupabaseClient(config);
+  const timestamp = emailedAtIso ?? new Date().toISOString();
 
   try {
     logger.info('Marking posts as emailed', { postCount: postIds.length });
 
     const { error } = await supabase
       .from('reddit_posts')
-      .update({ emailed_at: new Date().toISOString() } as any)
+      .update({ emailed_at: timestamp } as any)
       .in('post_id', postIds);
 
     if (error) {

--- a/lib/price-watch.ts
+++ b/lib/price-watch.ts
@@ -1,7 +1,7 @@
 import type { Config } from './config';
 import { getSupabaseClient } from './db';
 import { logger } from './logger';
-import { TiingoClient, findLastBarOnOrBefore } from './tiingo';
+import { TiingoClient, findLastBarOnOrBefore, type IntradayBar } from './tiingo';
 import {
   easternMarketClose,
   easternMarketOpen,
@@ -345,7 +345,7 @@ export async function processPriceWatchQueue(
 
   for (const [ticker, rows] of groups.entries()) {
     const window = computeTiingoWindow(rows, now);
-    let series = [];
+    let series: IntradayBar[] = [];
     try {
       series = await tiingo.fetchIntraday({
         ticker,

--- a/lib/price-watch.ts
+++ b/lib/price-watch.ts
@@ -1,0 +1,489 @@
+import type { Config } from './config';
+import { getSupabaseClient } from './db';
+import { logger } from './logger';
+import { TiingoClient, findLastBarOnOrBefore } from './tiingo';
+import {
+  easternMarketClose,
+  easternMarketOpen,
+  isDuringEasternMarketHours,
+  isEasternWeekend,
+  nextEasternBusinessDay,
+} from './time';
+
+const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+const DATA_UNAVAILABLE_BACKOFF_MS = 60 * 60 * 1000; // retry in 1 hour if no data
+const TIINGO_LOOKBACK_PADDING_MS = 30 * 60 * 1000; // 30 minutes padding for intraday fetches
+const DEFAULT_LIMIT = 200;
+
+type SupabaseClient = ReturnType<typeof getSupabaseClient>;
+
+type Logger = ReturnType<typeof logger.withContext>;
+
+export interface PriceWatchSeed {
+  postId: string;
+  ticker: string;
+  qualityScore: number;
+  emailedAtIso: string;
+  entryPrice: number;
+  entryPriceObservedAtIso: string;
+}
+
+export interface PriceWatchAlertInfo {
+  watchId: number;
+  postId: string;
+  ticker: string;
+  title: string;
+  url: string;
+  qualityScore: number;
+  entryPrice: number;
+  entryPriceObservedAtIso: string;
+  currentPrice: number;
+  movePct: number;
+  triggeredAtIso: string;
+  emailedAtIso: string;
+}
+
+export interface PriceWatchProcessResult {
+  checked: number;
+  triggered: PriceWatchAlertInfo[];
+  expired: number;
+  rescheduled: number;
+  dataUnavailable: number;
+  exceededFifteenPct: number;
+}
+
+interface DbPriceWatchRow {
+  id: number;
+  post_id: string;
+  ticker: string;
+  quality_score: number | null;
+  entry_price: number | string | null;
+  entry_price_ts: string | null;
+  emailed_at: string;
+  monitor_start_at: string;
+  monitor_close_at: string;
+  next_check_at: string | null;
+  last_price: number | string | null;
+  last_price_ts: string | null;
+  reddit_posts?: {
+    title?: string | null;
+    url?: string | null;
+  } | null;
+}
+
+interface PriceWatchUpdate {
+  id: number;
+  status?: 'pending' | 'triggered' | 'expired';
+  stop_reason?: string | null;
+  next_check_at?: string | null;
+  last_price?: number | null;
+  last_price_ts?: string | null;
+  triggered_at?: string | null;
+  triggered_price?: number | null;
+  triggered_move_pct?: number | null;
+}
+
+function computeMonitorWindow(emailedAt: Date): { start: Date; close: Date } {
+  if (isDuringEasternMarketHours(emailedAt)) {
+    return {
+      start: emailedAt,
+      close: easternMarketClose(emailedAt),
+    };
+  }
+
+  if (isEasternWeekend(emailedAt)) {
+    let next = emailedAt;
+    do {
+      next = nextEasternBusinessDay(next);
+    } while (isEasternWeekend(next));
+    const start = easternMarketOpen(next);
+    return { start, close: easternMarketClose(start) };
+  }
+
+  const open = easternMarketOpen(emailedAt);
+  const close = easternMarketClose(emailedAt);
+
+  if (emailedAt < open) {
+    return { start: open, close };
+  }
+
+  if (emailedAt >= close) {
+    let next = emailedAt;
+    do {
+      next = nextEasternBusinessDay(next);
+    } while (isEasternWeekend(next));
+    const start = easternMarketOpen(next);
+    return { start, close: easternMarketClose(start) };
+  }
+
+  return { start: emailedAt, close };
+}
+
+function uniqueSeeds(seeds: PriceWatchSeed[]): PriceWatchSeed[] {
+  const seen = new Set<string>();
+  const result: PriceWatchSeed[] = [];
+  for (const seed of seeds) {
+    const key = `${seed.postId}::${seed.ticker.toUpperCase()}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push({
+      ...seed,
+      ticker: seed.ticker.toUpperCase(),
+    });
+  }
+  return result;
+}
+
+function isValidSeed(seed: PriceWatchSeed): boolean {
+  return (
+    typeof seed.postId === 'string'
+    && seed.postId.length > 0
+    && typeof seed.ticker === 'string'
+    && seed.ticker.length > 0
+    && Number.isFinite(seed.entryPrice)
+    && seed.entryPrice > 0
+  );
+}
+
+export async function schedulePriceWatches(
+  config: Config,
+  seeds: PriceWatchSeed[],
+  requestLogger: Logger,
+): Promise<number> {
+  const supabase = getSupabaseClient(config);
+  const validSeeds = uniqueSeeds(seeds).filter(isValidSeed);
+
+  if (validSeeds.length === 0) {
+    requestLogger.debug('No price watch seeds to schedule');
+    return 0;
+  }
+
+  const rows = validSeeds.map(seed => {
+    const emailedAt = new Date(seed.emailedAtIso);
+    const { start, close } = computeMonitorWindow(emailedAt);
+    const observedCandidate = new Date(seed.entryPriceObservedAtIso || seed.emailedAtIso);
+    const entryObservedAt = Number.isNaN(observedCandidate.getTime())
+      ? emailedAt
+      : observedCandidate;
+
+    return {
+      post_id: seed.postId,
+      ticker: seed.ticker.toUpperCase(),
+      quality_score: seed.qualityScore,
+      entry_price: seed.entryPrice,
+      entry_price_ts: entryObservedAt.toISOString(),
+      emailed_at: seed.emailedAtIso,
+      monitor_start_at: start.toISOString(),
+      monitor_close_at: close.toISOString(),
+      next_check_at: start.toISOString(),
+      status: 'pending',
+      stop_reason: null,
+    };
+  });
+
+  requestLogger.info('Scheduling price watch tasks', {
+    taskCount: rows.length,
+  });
+
+  const { error } = await supabase
+    .from('price_watches')
+    .upsert(rows as any, {
+      onConflict: 'post_id,ticker',
+      ignoreDuplicates: true,
+    });
+
+  if (error) {
+    requestLogger.error('Failed to schedule price watches', {
+      error: error.message,
+    });
+    throw new Error(`Failed to schedule price watches: ${error.message}`);
+  }
+
+  return rows.length;
+}
+
+function groupByTicker(rows: DbPriceWatchRow[]): Map<string, DbPriceWatchRow[]> {
+  const map = new Map<string, DbPriceWatchRow[]>();
+  for (const row of rows) {
+    const ticker = (row.ticker || '').toUpperCase();
+    if (!ticker) continue;
+    if (!map.has(ticker)) {
+      map.set(ticker, []);
+    }
+    map.get(ticker)!.push(row);
+  }
+  return map;
+}
+
+function parseNumber(value: number | string | null | undefined): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function computeTiingoWindow(rows: DbPriceWatchRow[], now: Date): { start: Date; end: Date } {
+  let earliest = now.getTime();
+  for (const row of rows) {
+    const candidates: Array<string | null | undefined> = [row.monitor_start_at, row.entry_price_ts];
+    for (const candidate of candidates) {
+      if (!candidate) continue;
+      const ms = new Date(candidate).getTime();
+      if (!Number.isFinite(ms)) continue;
+      if (ms < earliest) {
+        earliest = ms;
+      }
+    }
+  }
+  const start = new Date(Math.max(earliest - TIINGO_LOOKBACK_PADDING_MS, now.getTime() - 3 * 24 * 60 * 60 * 1000));
+  return { start, end: now };
+}
+
+async function fetchDuePriceWatches(
+  supabase: SupabaseClient,
+  nowIso: string,
+): Promise<DbPriceWatchRow[]> {
+  const { data, error } = await supabase
+    .from('price_watches')
+    .select(`
+      id,
+      post_id,
+      ticker,
+      quality_score,
+      entry_price,
+      entry_price_ts,
+      emailed_at,
+      monitor_start_at,
+      monitor_close_at,
+      next_check_at,
+      last_price,
+      last_price_ts,
+      reddit_posts ( title, url )
+    `)
+    .eq('status', 'pending')
+    .lte('next_check_at', nowIso)
+    .order('next_check_at', { ascending: true })
+    .limit(DEFAULT_LIMIT);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data ?? []) as DbPriceWatchRow[];
+}
+
+async function applyUpdates(
+  supabase: SupabaseClient,
+  updates: PriceWatchUpdate[],
+  requestLogger: Logger,
+) {
+  for (const update of updates) {
+    const payload: Record<string, any> = {
+      updated_at: new Date().toISOString(),
+    };
+
+    if (update.status) payload.status = update.status;
+    if (update.stop_reason !== undefined) payload.stop_reason = update.stop_reason;
+    if (update.next_check_at !== undefined) payload.next_check_at = update.next_check_at;
+    if (update.last_price !== undefined) payload.last_price = update.last_price;
+    if (update.last_price_ts !== undefined) payload.last_price_ts = update.last_price_ts;
+    if (update.triggered_at !== undefined) payload.triggered_at = update.triggered_at;
+    if (update.triggered_price !== undefined) payload.triggered_price = update.triggered_price;
+    if (update.triggered_move_pct !== undefined) payload.triggered_move_pct = update.triggered_move_pct;
+
+    const { error } = await supabase
+      .from('price_watches')
+      .update(payload as any)
+      .eq('id', update.id);
+
+    if (error) {
+      requestLogger.error('Failed to update price watch row', {
+        id: update.id,
+        error: error.message,
+      });
+      throw new Error(`Failed to update price watch row: ${error.message}`);
+    }
+  }
+}
+
+export async function processPriceWatchQueue(
+  config: Config,
+  requestLogger: Logger,
+  now: Date = new Date(),
+): Promise<PriceWatchProcessResult> {
+  const supabase = getSupabaseClient(config);
+  const nowIso = now.toISOString();
+
+  const pendingRows = await fetchDuePriceWatches(supabase, nowIso);
+  if (pendingRows.length === 0) {
+    return {
+      checked: 0,
+      triggered: [],
+      expired: 0,
+      rescheduled: 0,
+      dataUnavailable: 0,
+      exceededFifteenPct: 0,
+    };
+  }
+
+  const tiingo = new TiingoClient(config.marketData.tiingoApiKey);
+  const groups = groupByTicker(pendingRows);
+  const updates: PriceWatchUpdate[] = [];
+  const alerts: PriceWatchAlertInfo[] = [];
+
+  let checked = 0;
+  let expired = 0;
+  let rescheduled = 0;
+  let dataUnavailable = 0;
+  let exceededFifteenPct = 0;
+
+  for (const [ticker, rows] of groups.entries()) {
+    const window = computeTiingoWindow(rows, now);
+    let series = [];
+    try {
+      series = await tiingo.fetchIntraday({
+        ticker,
+        start: window.start,
+        end: window.end,
+        frequency: '5min',
+      });
+    } catch (error) {
+      requestLogger.warn('Failed to fetch Tiingo data for price watch', {
+        ticker,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      series = [];
+    }
+
+    for (const row of rows) {
+      checked += 1;
+      const entryPrice = parseNumber(row.entry_price);
+      if (!entryPrice || entryPrice <= 0) {
+        updates.push({
+          id: row.id,
+          status: 'expired',
+          stop_reason: 'invalid_entry_price',
+          next_check_at: null,
+        });
+        expired += 1;
+        continue;
+      }
+
+      const closeAt = new Date(row.monitor_close_at);
+      const currentBar = series.length > 0 ? findLastBarOnOrBefore(series, now) : undefined;
+
+      if (!currentBar) {
+        dataUnavailable += 1;
+        if (now >= closeAt) {
+          updates.push({
+            id: row.id,
+            status: 'expired',
+            stop_reason: 'market_close',
+            next_check_at: null,
+            last_price: null,
+            last_price_ts: null,
+          });
+          expired += 1;
+        } else {
+          const nextCheckMs = Math.min(now.getTime() + DATA_UNAVAILABLE_BACKOFF_MS, closeAt.getTime());
+          const nextCheckIso = new Date(nextCheckMs).toISOString();
+          updates.push({
+            id: row.id,
+            next_check_at: nextCheckIso,
+            last_price: null,
+            last_price_ts: null,
+          });
+          rescheduled += 1;
+        }
+        continue;
+      }
+
+      const currentPrice = currentBar.close ?? currentBar.open;
+      const barTimestamp = currentBar.timestamp;
+      if (!currentPrice || currentPrice <= 0) {
+        dataUnavailable += 1;
+        const nextCheckMs = Math.min(now.getTime() + DATA_UNAVAILABLE_BACKOFF_MS, closeAt.getTime());
+        updates.push({
+          id: row.id,
+          next_check_at: new Date(nextCheckMs).toISOString(),
+          last_price: null,
+          last_price_ts: null,
+        });
+        rescheduled += 1;
+        continue;
+      }
+
+      const movePct = (currentPrice - entryPrice) / entryPrice;
+      const fifteenPctThreshold = 0.15;
+      const fivePctThreshold = 0.05;
+      const update: PriceWatchUpdate = {
+        id: row.id,
+        last_price: currentPrice,
+        last_price_ts: barTimestamp,
+      };
+
+      if (movePct >= fifteenPctThreshold) {
+        update.status = 'expired';
+        update.stop_reason = 'above_15pct';
+        update.next_check_at = null;
+        exceededFifteenPct += 1;
+        expired += 1;
+      } else if (movePct <= fivePctThreshold) {
+        const triggeredAtIso = nowIso;
+        update.status = 'triggered';
+        update.stop_reason = 'triggered';
+        update.next_check_at = null;
+        update.triggered_at = triggeredAtIso;
+        update.triggered_price = currentPrice;
+        update.triggered_move_pct = movePct;
+
+        const alert: PriceWatchAlertInfo = {
+          watchId: row.id,
+          postId: row.post_id,
+          ticker,
+          title: row.reddit_posts?.title ?? '(unknown title)',
+          url: row.reddit_posts?.url ?? '',
+          qualityScore: Number(row.quality_score ?? 0),
+          entryPrice,
+          entryPriceObservedAtIso: row.entry_price_ts ?? row.emailed_at,
+          currentPrice,
+          movePct,
+          triggeredAtIso,
+          emailedAtIso: row.emailed_at,
+        };
+        alerts.push(alert);
+      } else if (now >= closeAt) {
+        update.status = 'expired';
+        update.stop_reason = 'market_close';
+        update.next_check_at = null;
+        expired += 1;
+      } else {
+        const nextCheckMs = Math.min(now.getTime() + CHECK_INTERVAL_MS, closeAt.getTime());
+        update.next_check_at = new Date(nextCheckMs).toISOString();
+        rescheduled += 1;
+      }
+
+      updates.push(update);
+    }
+  }
+
+  if (updates.length > 0) {
+    await applyUpdates(supabase, updates, requestLogger);
+  }
+
+  return {
+    checked,
+    triggered: alerts,
+    expired,
+    rescheduled,
+    dataUnavailable,
+    exceededFifteenPct,
+  };
+}
+

--- a/lib/time.ts
+++ b/lib/time.ts
@@ -95,3 +95,30 @@ export function addDays(date: Date, days: number): Date {
   result.setUTCDate(result.getUTCDate() + days);
   return result;
 }
+
+export function nextEasternBusinessDay(date: Date): Date {
+  let probe = addDays(date, 1);
+  while (isEasternWeekend(probe)) {
+    probe = addDays(probe, 1);
+  }
+  return probe;
+}
+
+export function easternMarketOpen(date: Date): Date {
+  const { year, month, day } = getEasternComponents(date);
+  return easternDateTime(year, month, day, 9, 30);
+}
+
+export function easternMarketClose(date: Date): Date {
+  const { year, month, day } = getEasternComponents(date);
+  return easternDateTime(year, month, day, 16, 0);
+}
+
+export function isDuringEasternMarketHours(date: Date): boolean {
+  if (isEasternWeekend(date)) {
+    return false;
+  }
+  const open = easternMarketOpen(date);
+  const close = easternMarketClose(date);
+  return date >= open && date <= close;
+}

--- a/supabase/migrations/20250215000000_add_price_watches.sql
+++ b/supabase/migrations/20250215000000_add_price_watches.sql
@@ -1,0 +1,27 @@
+create table if not exists price_watches (
+  id bigserial primary key,
+  post_id text not null references reddit_posts(post_id) on delete cascade,
+  ticker text not null,
+  quality_score int not null,
+  entry_price numeric not null,
+  entry_price_ts timestamptz not null,
+  emailed_at timestamptz not null,
+  monitor_start_at timestamptz not null,
+  monitor_close_at timestamptz not null,
+  next_check_at timestamptz,
+  last_price numeric,
+  last_price_ts timestamptz,
+  status text not null default 'pending' check (status in ('pending', 'triggered', 'expired')),
+  stop_reason text,
+  triggered_at timestamptz,
+  triggered_price numeric,
+  triggered_move_pct numeric,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists idx_price_watches_post_ticker on price_watches(post_id, ticker);
+create index if not exists idx_price_watches_status_next on price_watches(status, next_check_at);
+create index if not exists idx_price_watches_next_check on price_watches(next_check_at);
+
+alter table price_watches disable row level security;

--- a/tests/time.test.ts
+++ b/tests/time.test.ts
@@ -5,6 +5,10 @@ import {
   getEasternComponents,
   isEasternWeekend,
   startOfEasternDay,
+  nextEasternBusinessDay,
+  easternMarketOpen,
+  easternMarketClose,
+  isDuringEasternMarketHours,
 } from '../lib/time';
 
 describe('getEasternComponents', () => {
@@ -72,5 +76,69 @@ describe('addDays', () => {
     const result = addDays(initial, 5);
 
     expect(result.toISOString()).toBe('2023-03-15T05:00:00.000Z');
+  });
+});
+
+describe('nextEasternBusinessDay', () => {
+  it('moves to Monday when given a Friday', () => {
+    const friday = new Date('2023-12-15T17:30:00Z');
+    const next = nextEasternBusinessDay(friday);
+    expect(next.toISOString().slice(0, 10)).toBe('2023-12-18');
+  });
+
+  it('returns following Monday when input date is Saturday', () => {
+    const saturday = new Date('2023-12-16T12:00:00Z');
+    const next = nextEasternBusinessDay(saturday);
+    expect(next.toISOString().slice(0, 10)).toBe('2023-12-18');
+  });
+
+  it('returns following Monday when input date is Sunday', () => {
+    const sunday = new Date('2023-12-17T12:00:00Z');
+    const next = nextEasternBusinessDay(sunday);
+    expect(next.toISOString().slice(0, 10)).toBe('2023-12-18');
+  });
+});
+
+describe('easternMarketOpen/Close', () => {
+  it('returns 9:30 ET open and 16:00 ET close in standard time', () => {
+    const date = new Date('2023-12-15T17:30:00Z');
+    const open = easternMarketOpen(date);
+    const close = easternMarketClose(date);
+    expect(open.toISOString()).toBe('2023-12-15T14:30:00.000Z'); // 9:30 ET = 14:30Z in EST (UTC-5)
+    expect(close.toISOString()).toBe('2023-12-15T21:00:00.000Z'); // 16:00 ET = 21:00Z in EST
+  });
+
+  it('returns 9:30 ET open and 16:00 ET close in daylight time', () => {
+    const date = new Date('2023-07-05T16:00:00Z');
+    const open = easternMarketOpen(date);
+    const close = easternMarketClose(date);
+    expect(open.toISOString()).toBe('2023-07-05T13:30:00.000Z'); // 9:30 ET = 13:30Z in EDT (UTC-4)
+    expect(close.toISOString()).toBe('2023-07-05T20:00:00.000Z'); // 16:00 ET = 20:00Z in EDT
+  });
+});
+
+describe('isDuringEasternMarketHours', () => {
+  it('is false on weekends', () => {
+    expect(isDuringEasternMarketHours(new Date('2023-12-16T15:00:00Z'))).toBe(false); // Saturday
+    expect(isDuringEasternMarketHours(new Date('2023-12-17T15:00:00Z'))).toBe(false); // Sunday
+  });
+
+  it('is false before open and after close on a weekday (EST)', () => {
+    // 2023-12-15 is Friday
+    expect(isDuringEasternMarketHours(new Date('2023-12-15T14:29:59Z'))).toBe(false); // 9:29:59 ET
+    expect(isDuringEasternMarketHours(new Date('2023-12-15T21:00:01Z'))).toBe(false); // 16:00:01 ET
+  });
+
+  it('is true at boundaries inclusive (EST)', () => {
+    expect(isDuringEasternMarketHours(new Date('2023-12-15T14:30:00Z'))).toBe(true); // open
+    expect(isDuringEasternMarketHours(new Date('2023-12-15T21:00:00Z'))).toBe(true); // close
+  });
+
+  it('works during DST (EDT)', () => {
+    // 2023-07-05 is Wednesday
+    expect(isDuringEasternMarketHours(new Date('2023-07-05T13:29:59Z'))).toBe(false); // 9:29:59 ET
+    expect(isDuringEasternMarketHours(new Date('2023-07-05T13:30:00Z'))).toBe(true);  // open
+    expect(isDuringEasternMarketHours(new Date('2023-07-05T20:00:00Z'))).toBe(true);  // close
+    expect(isDuringEasternMarketHours(new Date('2023-07-05T20:00:01Z'))).toBe(false); // after close
   });
 });


### PR DESCRIPTION
## Summary
- add hourly price watch queue processing to the poll workflow and store watch tasks for high-quality tickers
- introduce email alerts for price watch triggers and support functions for fetching monitor windows
- add schema and Supabase migration for the new price_watches table

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e334ed142083329013c39561fc676f