### PR TITLE
Fix entry price selection for stock watch emails

### DIFF
--- a/lambda/poll.ts
+++ b/lambda/poll.ts
@@ -114,7 +114,13 @@ async function annotateCandidatesWithPriceMove(
           continue;
         }
 
-        const entryBar = findFirstBarOnOrAfter(series, new Date(createdMs));
+        const createdDate = new Date(createdMs);
+        // Use the most recent bar at or before the post time so we capture
+        // a price even if the next bar hasn't printed yet (e.g. post created
+        // between intraday intervals). If none exists, fall back to the next
+        // available bar so we still provide a reasonable entry price.
+        const entryBar = findLastBarOnOrBefore(series, createdDate)
+          ?? findFirstBarOnOrAfter(series, createdDate);
         const latestBar = findLastBarOnOrBefore(series, now);
 
         const entryPrice = entryBar?.close ?? entryBar?.open ?? null;


### PR DESCRIPTION
## Summary
- select the most recent intraday bar at or before post creation when computing price insights
- fall back to the next available bar so emails no longer report price data as unavailable right after a post

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68e3afaf026083329ad6307e1e2b2992