### PR TITLE
Refactor email generation for clarity

### DIFF
--- a/lib/email-utils.ts
+++ b/lib/email-utils.ts
@@ -1,0 +1,65 @@
+import { EASTERN_TIMEZONE } from './time';
+
+export function formatUsd(value?: number | null): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 'n/a';
+  }
+  return `$${value.toFixed(2)}`;
+}
+
+export function formatPct(value?: number | null): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 'n/a';
+  }
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${(value * 100).toFixed(2)}%`;
+}
+
+export function formatEtTimestamp(isoString: string): string {
+  if (!isoString) {
+    return 'n/a';
+  }
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) {
+    return 'n/a';
+  }
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: EASTERN_TIMEZONE,
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true,
+  }).format(date);
+}
+
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function getTimeAgo(isoString: string, reference: Date = new Date()): string {
+  const postTime = new Date(isoString);
+  if (Number.isNaN(postTime.getTime())) {
+    return 'n/a';
+  }
+  const diffMs = reference.getTime() - postTime.getTime();
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+
+  if (diffHours > 24) {
+    const diffDays = Math.floor(diffHours / 24);
+    return `${diffDays} day${diffDays > 1 ? 's' : ''} ago`;
+  }
+
+  if (diffHours > 0) {
+    return `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`;
+  }
+
+  return `${diffMins} minute${diffMins > 1 ? 's' : ''} ago`;
+}


### PR DESCRIPTION
## Summary
- extract reusable email formatting helpers for currencies, percentages, timestamps, and escaping
- reorganize email composition so digest, price watch, and performance reports share a common sender and dedicated builders
- streamline preview support to reuse the same digest content pipeline

## Testing
- npm run type-check *(fails: missing type declarations for dayjs/vitest packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e43f416b1083329190844bbbff92a0